### PR TITLE
Bug importante al normalizar numero

### DIFF
--- a/src/Sbif.php
+++ b/src/Sbif.php
@@ -310,6 +310,8 @@ class Sbif
      */
     private function normalizeNumber($number)
     {
+        $number = str_replace(".", "", $number);
+        
         return (float)str_replace(",", ".", $number);
     }
 }


### PR DESCRIPTION
Números tipo 10.000,00 (como la uf) se convertían a 10.00 , revisar la conversión de otros valores. (En general se observa que la api devuelve valores con separador "." y decimal "," ). Igualmente convendrá crear un script de testing.